### PR TITLE
Fixed issue where branched paths could cut each other off

### DIFF
--- a/Assets/Scripts/TileManager.cs
+++ b/Assets/Scripts/TileManager.cs
@@ -193,6 +193,8 @@ public class TileManager : MonoBehaviour{
                 nextPoint.z = tilePoint.z;
                 if(tileList.Contains(nextPoint)){
                     return false;
+                } else {
+                    tileList.Add(nextPoint);
                 }
                 break;
             case "right":
@@ -200,6 +202,8 @@ public class TileManager : MonoBehaviour{
                 nextPoint.z = tilePoint.z - 7;
                 if(tileList.Contains(nextPoint)){
                     return false;
+                } else {
+                    tileList.Add(nextPoint);
                 }
                 break;
             case "down":
@@ -207,6 +211,8 @@ public class TileManager : MonoBehaviour{
                 nextPoint.z = tilePoint.z;
                 if(tileList.Contains(nextPoint)){
                     return false;
+                } else {
+                    tileList.Add(nextPoint);
                 }
                 break;
             case "left":
@@ -214,6 +220,8 @@ public class TileManager : MonoBehaviour{
                 nextPoint.z = tilePoint.z + 7;
                 if(tileList.Contains(nextPoint)){
                     return false;
+                } else {
+                    tileList.Add(nextPoint);
                 }
                 break;
             default:


### PR DESCRIPTION
Adds tile point as well as the next tile point to the list of tiles so that you cannot turn into that spot. **Has not been thoroughly tested due to rarity of possibility.